### PR TITLE
Pulled development fork fixes for Bruker data and dependency install fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Full instructions for data processing are included in the MPACT manual.
 _Updates in Rev 22.02.26_
 
 - Added filtering of database hits by kingdom and genus
+- Dependency check script spawns a window if any dependencies were installed informing user the kernal will restart.
+- Bugfixes in group set interactions, and bruker data import
 
 _Updates in Rev 22.02.19_
 

--- a/code/filter.py
+++ b/code/filter.py
@@ -157,8 +157,12 @@ def decon(analysis_params, ionfilters):
     iondict['pass_insource'] = ~iondict.index.isin(ionfilters['insource'].ions)
     iondict.to_csv(analysis_params.outputdir / 'iondict.csv', header=True, index=True)
     
-    # Convert ion filters to MSP format
-    mspwriter.convert_to_msp(ionfilters['insource'], analysis_params)
+    # Convert ion filters to MSP format passes and prints errors
+    try:
+        mspwriter.convert_to_msp(ionfilters['insource'], analysis_params)
+    except Exception:
+        print('Error in MSP writer')
+        pass
     
     return ionfilters
 

--- a/code/importdependencies.py
+++ b/code/importdependencies.py
@@ -5,15 +5,22 @@ Copyright 2022, Robert M. Samples, Sara P. Puckett, and Marcy J. Balunas
 
 import subprocess
 import sys
+from tkinter import * 
+from tkinter import messagebox
+import os
+
 
 def install(package):
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+    
 
 installlist = {"epam.indigo":"indigo",
                "UpSetPlot":"upsetplot",
                "squarify":"squarify"}
 
+
 def checkdep():
+    restartflag = False
     installlist = {"epam.indigo":"indigo",
                    "UpSetPlot":"upsetplot",
                    "squarify":"squarify"}
@@ -22,5 +29,36 @@ def checkdep():
         if installlist[package] in sys.modules:
             print(package + " already installed")
         else:
+            restartflag = True
             print('installing ' + package)
             install(package)
+    
+    if restartflag:
+        root = Tk()
+        root.geometry("1x1")
+        if messagebox.showinfo("Restart", "Dependencies installed, the kernal will restart\n Please restart MPACT"):
+            os._exit(00)
+        
+        root.mainloop()
+        
+        """
+        #code for pyqt version, doesn't work if main window not initialized
+        def show_info_messagebox():
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Information)
+          
+            # setting message for Message Box
+            msg.setText("Information ")
+              
+            # setting Message box window title
+            msg.setWindowTitle("Information MessageBox")
+              
+            # declaring buttons on Message Box
+            msg.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
+              
+            # start the app
+            retval = msg.exec_()
+                
+            show_info_messagebox()
+        show_info_messagebox()
+        """

--- a/code/main.py
+++ b/code/main.py
@@ -196,6 +196,12 @@ class MainWindow(QMainWindow):
     def __init__(self):
         QMainWindow.__init__(self)
         self.ui = Ui_MainWindow()
+        
+        self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)  # set always on top flag, makes window disappear
+        self.show() # makes window reappear, but it's ALWAYS on top
+        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowStaysOnTopHint) # clear always on top flag, makes window disappear
+        #self.show() # makes window reappear, acts like normal window now (on top now but can be underneath if you raise another window)
+        
         self.ui.setupUi(self)
         self.ui.label_credits.setText('Rev 23.02.26')
                 
@@ -715,8 +721,8 @@ class MainWindow(QMainWindow):
             UIFunctions.updategroups(self)
         else:
             self.selset = self.ui.listWidget_pltgrps.currentRow()
-            UIFunctions.updategroups(self)
             UIFunctions.writegroups(self)
+            UIFunctions.updategroups(self)
         
         self.analysis_paramsgui.kingdom = self.ui.combo_kingdom.currentText()
         self.analysis_paramsgui.genus = str(self.ui.lineEdit_genus.text())
@@ -766,7 +772,7 @@ class MainWindow(QMainWindow):
         self.analysis_paramsgui.samplelistfilename = self.samplelistfilename
         self.analysis_paramsgui.extractmetadatafilename = self.extractmetadatafilename 
         if self.outputdir == '':
-            self.outputdir.set(Path(self.analysis_paramsgui.filename).parent)
+            self.outputdir = (Path(self.analysis_paramsgui.filename).parent)
         self.analysis_paramsgui.outputdir = self.outputdir
         self.analysis_paramsgui.fragfilename = self.fragfilename
         Path(self.analysis_paramsgui.outputdir / self.analysis_paramsgui.filename.stem).mkdir(parents=True, exist_ok=True)

--- a/code/mspwriter.py
+++ b/code/mspwriter.py
@@ -27,12 +27,16 @@ def convert_to_msp(ionfilter_obj, analysis_params):
     - Reads the input csv file and extracts the relevant data
     - Writes a .msp file containing the relevant data from the ionfilter object
     """
+    
     msdata = round(pd.read_csv(analysis_params.filename, sep = ',', header = [0,1,2], index_col = [0]).iloc[:,2:].transpose().mean(), 4)
     ionmerge = ionfilter_obj.merge
     with open(str(analysis_params.outputdir / (analysis_params.filename.stem + '.msp')), 'w') as f:
         keys = list(ionfilter_obj.merge.keys())
         for precursor in keys:
-            mass = ionmerge[precursor].target.split('_')[1].strip('m/z').strip('n')
+            if 'Da' in ionmerge[precursor].target:
+                mass = ionmerge[precursor].target.split(' ')[0]
+            else:
+                mass = ionmerge[precursor].target.split('_')[1].strip('m/z').strip('n')
             f.write('Name: Unknown (' + ionmerge[precursor].target + ')\n')  # MSP file requires a name field, but it can be left empty
             f.write('Charge:\n')  # MSP file requires a formula field, but it can be left empty
             f.write('Precursor: ' + mass + '\n')  # MSP file requires a formula field, but it can be left empty
@@ -44,7 +48,10 @@ def convert_to_msp(ionfilter_obj, analysis_params):
             f.write('Num peaks: ' + str(numpeaks) + '\n')  # Number of peaks
             for frags in sources:
                 for fragment in frags:
-                    f.write(fragment.split('_')[1].strip('m/z').strip('n') + ' ' + str(msdata.loc[fragment]) + '\n')  # Write each source fragment
+                    if 'Da' in ionmerge[precursor].target:
+                        f.write(fragment.split(' ')[0] + ' ' + str(msdata.loc[fragment]) + '\n')  # Write each source fragment
+                    else:
+                        f.write(fragment.split('_')[1].strip('m/z').strip('n') + ' ' + str(msdata.loc[fragment]) + '\n')  # Write each source fragment
             f.write('\n')  # MSP file requires a name field, but it can be left empty
             
         f.close()

--- a/code/ui_functions.py
+++ b/code/ui_functions.py
@@ -578,5 +578,6 @@ class UIFunctions(MainWindow):
     
     def show_ftrdialog(self):
         self.ftrdialog.show()
-        self.highlight_feature(self.pickedfeature)
+        if self.pickedfeature != '':
+            self.highlight_feature(self.pickedfeature)
 


### PR DESCRIPTION
Fixed issue with bruker/metaboscape files where MSP writer would throw an error

package autoinstaller worked but the rest of the code would not run if kernal was not restarted, notification window spawned informing the user, kernal restarts when user closes notification

Default output path if none are selected is fixed

issue where selected groupset would not save if not toggled between sets fixed

MPACT now spawns as the top window when started